### PR TITLE
Fix the error: Argument #1 ($class_nid) must be of type int, string given

### DIFF
--- a/src/EventSubscriber/OpenYCleanerRequestSubscriber.php
+++ b/src/EventSubscriber/OpenYCleanerRequestSubscriber.php
@@ -67,7 +67,7 @@ class OpenYCleanerRequestSubscriber implements EventSubscriberInterface {
       $node = $this->routeMatch->getParameter('node');
 
       if ($node instanceof NodeInterface && $node->getType() == 'class') {
-        $active_session = $this->sessionCleaner->getClassActiveSessions($node->id());
+        $active_session = $this->sessionCleaner->getClassActiveSessions((int) $node->id());
         if (empty($active_session)) {
           throw new NotFoundHttpException();
         }


### PR DESCRIPTION
After creating a new Class node, we got the error message:

> TypeError: Drupal\openy_session_cleaner\SessionCleaner::getClassActiveSessions(): Argument #1 ($class_nid) must be of type int, string given, called in /var/www/docroot/modules/contrib/openy_session_cleaner/src/EventSubscriber/OpenYCleanerRequestSubscriber.php on line 70 in Drupal\openy_session_cleaner\SessionCleaner->getClassActiveSessions() (line 201 of /var/www/docroot/modules/contrib/openy_session_cleaner/src/SessionCleaner.php).

This PR should fix it